### PR TITLE
Pass descriptors by reference with owned vecs

### DIFF
--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -136,11 +136,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/cube.vert.spv")),
+        code: include_bytes!("shaders/cube.vert.spv"),
     })?;
 
     let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/cube.frag.spv")),
+        code: include_bytes!("shaders/cube.frag.spv"),
     })?;
 
     #[rustfmt::skip]

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut uniforms = vec![Uniforms::default(); 1];
 
-    let mut encoder = app.device.create_command_encoder()?;
+    let mut encoder = app.device.create_command_encoder(None)?;
 
     let vertex_buffer = util::create_buffer_with_data(&app.device, &mut encoder, BufferUsageFlags::VERTEX, &vertices)?;
     let index_buffer = util::create_buffer_with_data(&app.device, &mut encoder, BufferUsageFlags::INDEX, &indices)?;
@@ -214,7 +214,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Err(e) => return Err(e)?,
         };
 
-        let mut encoder = app.device.create_command_encoder()?;
+        let mut encoder = app.device.create_command_encoder(None)?;
 
         let (attachment, resolve_target) = if app.get_sample_count() == 1 {
             (&frame.view, None)

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
     })?;
 
-    let pipeline_layout = app.device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let pipeline_layout = app.device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![bind_group_layout],
         push_constant_ranges: vec![],
     })?;

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -120,7 +120,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let bind_group = app.device.create_bind_group(BindGroupDescriptor {
+    let bind_group = app.device.create_bind_group(&BindGroupDescriptor {
         layout: bind_group_layout.clone(),
         bindings: vec![
             BindGroupBinding {

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -109,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     app.device.get_queue().submit(&[encoder.finish()?])?;
 
     #[rustfmt::skip]
-    let bind_group_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             BindGroupLayoutBinding {
                 binding: 0,

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -110,7 +110,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             BindGroupLayoutBinding {
                 binding: 0,
                 binding_type: BindingType::UniformBuffer,

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -135,11 +135,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         push_constant_ranges: vec![],
     })?;
 
-    let vs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/cube.vert.spv")),
     })?;
 
-    let fs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/cube.frag.spv")),
     })?;
 

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let render_pipeline = app.device.create_render_pipeline(RenderPipelineDescriptor {
+    let render_pipeline = app.device.create_render_pipeline(&RenderPipelineDescriptor {
         layout: pipeline_layout,
         vertex_stage: PipelineStageDescriptor { module: vs, entry_point: Cow::Borrowed("main") },
         fragment_stage: PipelineStageDescriptor { module: fs, entry_point: Cow::Borrowed("main") },

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -230,7 +230,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
     })?;
 
-    let pipeline_layout = app.device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let pipeline_layout = app.device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![bind_group_layout],
         push_constant_ranges: vec![],
     })?;

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             BindGroupLayoutBinding {
                 binding: 0,
                 binding_type: BindingType::UniformBuffer,

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         depth: 1,
     };
 
-    let sampler = app.device.create_sampler(SamplerDescriptor {
+    let sampler = app.device.create_sampler(&SamplerDescriptor {
         address_mode_u: AddressMode::ClampToEdge,
         address_mode_v: AddressMode::ClampToEdge,
         address_mode_w: AddressMode::ClampToEdge,

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut uniforms = vec![Uniforms::default(); 1];
 
-    let mut encoder = app.device.create_command_encoder()?;
+    let mut encoder = app.device.create_command_encoder(None)?;
 
     let vertex_buffer = util::create_buffer_with_data(&app.device, &mut encoder, BufferUsageFlags::VERTEX, &vertices)?;
     let index_buffer = util::create_buffer_with_data(&app.device, &mut encoder, BufferUsageFlags::INDEX, &indices)?;
@@ -316,7 +316,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Err(e) => return Err(e)?,
         };
 
-        let mut encoder = app.device.create_command_encoder()?;
+        let mut encoder = app.device.create_command_encoder(None)?;
 
         let (attachment, resolve_target) = if app.get_sample_count() == 1 {
             (&frame.view, None)

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -235,11 +235,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         push_constant_ranges: vec![],
     })?;
 
-    let vs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/cube_texture.vert.spv")),
     })?;
 
-    let fs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/cube_texture.frag.spv")),
     })?;
 

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -191,7 +191,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     app.device.get_queue().submit(&[encoder.finish()?])?;
 
     #[rustfmt::skip]
-    let bind_group_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             BindGroupLayoutBinding {
                 binding: 0,

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("lod mip_levels: {}", mip_level_count);
 
-    let container_texture = app.device.create_texture(TextureDescriptor {
+    let container_texture = app.device.create_texture(&TextureDescriptor {
         mip_level_count,
         sample_count: 1,
         array_layer_count: 1,

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -212,7 +212,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let bind_group = app.device.create_bind_group(BindGroupDescriptor {
+    let bind_group = app.device.create_bind_group(&BindGroupDescriptor {
         layout: bind_group_layout.clone(),
         bindings: vec![
             BindGroupBinding {

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -236,11 +236,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/cube_texture.vert.spv")),
+        code: include_bytes!("shaders/cube_texture.vert.spv"),
     })?;
 
     let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/cube_texture.frag.spv")),
+        code: include_bytes!("shaders/cube_texture.frag.spv"),
     })?;
 
     #[rustfmt::skip]

--- a/examples/cube_texture.rs
+++ b/examples/cube_texture.rs
@@ -244,7 +244,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let render_pipeline = app.device.create_render_pipeline(RenderPipelineDescriptor {
+    let render_pipeline = app.device.create_render_pipeline(&RenderPipelineDescriptor {
         layout: pipeline_layout,
         vertex_stage: PipelineStageDescriptor { module: vs, entry_point: Cow::Borrowed("main") },
         fragment_stage: PipelineStageDescriptor { module: fs, entry_point: Cow::Borrowed("main") },

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1567,7 +1567,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Creating camera and light bind group (0)");
     #[rustfmt::skip]
-    let bind_group_0 = app.device.create_bind_group(BindGroupDescriptor {
+    let bind_group_0 = app.device.create_bind_group(&BindGroupDescriptor {
         layout: bind_group_0_layout.clone(),
         bindings: vec![
             BindGroupBinding {
@@ -1651,7 +1651,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             add_texture_sampler(9, 10, texture_sampler);
         }
 
-        bind_group_1.push(app.device.create_bind_group(BindGroupDescriptor {
+        bind_group_1.push(app.device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_1_layout.clone(),
             bindings,
         })?);
@@ -1659,7 +1659,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Creating mesh and skin bind group (2)");
     #[rustfmt::skip]
-    let bind_group_2 = app.device.create_bind_group(BindGroupDescriptor {
+    let bind_group_2 = app.device.create_bind_group(&BindGroupDescriptor {
         layout: bind_group_2_layout.clone(),
         bindings: vec![
             BindGroupBinding {

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1829,7 +1829,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             sample_count: app.get_sample_count(),
         };
 
-        let pipeline = app.device.create_render_pipeline(render_pipeline_descriptor)?;
+        let pipeline = app.device.create_render_pipeline(&render_pipeline_descriptor)?;
         pipelines.insert((material_pipeline_key, mesh_pipeline_key), pipeline);
     }
 

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -975,7 +975,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             MagFilter::Linear => FilterMode::Linear,
         };
 
-        samplers.push(app.device.create_sampler(SamplerDescriptor {
+        samplers.push(app.device.create_sampler(&SamplerDescriptor {
             address_mode_u: address_mode(sampler.wrap_s()),
             address_mode_v: address_mode(sampler.wrap_t()),
             address_mode_w: AddressMode::ClampToEdge,
@@ -988,7 +988,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?);
     }
 
-    let default_sampler = app.device.create_sampler(SamplerDescriptor {
+    let default_sampler = app.device.create_sampler(&SamplerDescriptor {
         address_mode_u: AddressMode::ClampToEdge,
         address_mode_v: AddressMode::ClampToEdge,
         address_mode_w: AddressMode::ClampToEdge,

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -866,7 +866,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let mut encoder = app.device.create_command_encoder()?;
+    let mut encoder = app.device.create_command_encoder(None)?;
 
     let _buffers: HashMap<usize, Buffer> = HashMap::with_capacity(import.buffers.len());
     let mut images = Vec::with_capacity(import.doc.images().len());
@@ -1849,7 +1849,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     app.run(move |app| {
         let now = Instant::now();
-        let mut encoder = app.device.create_command_encoder()?;
+        let mut encoder = app.device.create_command_encoder(None)?;
 
         let frame = match app.swapchain.acquire_next_image() {
             Ok(frame) => frame,

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1465,7 +1465,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let bind_group_0_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             // CameraAndLightSettings
             BindGroupLayoutBinding {
                 binding: 0,
@@ -1477,7 +1477,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let bind_group_1_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             // MaterialSettings
             BindGroupLayoutBinding {
                 binding: 0,
@@ -1549,7 +1549,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let bind_group_2_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             // MeshSettings
             BindGroupLayoutBinding {
                 binding: 0,

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1685,7 +1685,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         stages: ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT,
     };
 
-    let render_pipeline_layout = app.device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let render_pipeline_layout = app.device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![
             bind_group_0_layout.clone(),
             bind_group_1_layout.clone(),

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1464,7 +1464,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Unique mesh_pipeline_key: {:?}", mesh_pipeline_keys.len());
 
     #[rustfmt::skip]
-    let bind_group_0_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_0_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             // CameraAndLightSettings
             BindGroupLayoutBinding {
@@ -1476,7 +1476,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let bind_group_1_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_1_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             // MaterialSettings
             BindGroupLayoutBinding {
@@ -1548,7 +1548,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let bind_group_2_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_2_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             // MeshSettings
             BindGroupLayoutBinding {

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1696,11 +1696,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut pipelines = HashMap::with_capacity(pipeline_keys.len());
 
-    let vs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/gltf_viewer.vert.spv")),
     })?;
 
-    let fs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/gltf_viewer.frag.spv")),
     })?;
 

--- a/examples/gltf_viewer.rs
+++ b/examples/gltf_viewer.rs
@@ -1697,11 +1697,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut pipelines = HashMap::with_capacity(pipeline_keys.len());
 
     let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/gltf_viewer.vert.spv")),
+        code: include_bytes!("shaders/gltf_viewer.vert.spv"),
     })?;
 
     let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/gltf_viewer.frag.spv")),
+        code: include_bytes!("shaders/gltf_viewer.frag.spv"),
     })?;
 
     println!("Creating pipelines: {}", pipeline_keys.len());

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         1
     ];
 
-    let mut encoder = app.device.create_command_encoder()?;
+    let mut encoder = app.device.create_command_encoder(None)?;
 
     let attractor_buffer = util::create_buffer_with_data(
         &app.device,
@@ -382,7 +382,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Err(e) => return Err(e)?,
         };
 
-        let mut encoder = app.device.create_command_encoder()?;
+        let mut encoder = app.device.create_command_encoder(None)?;
 
         if app.state.reset1 {
             util::copy_to_buffer(&app.device, &mut encoder, &position_data, &position_buffer)?;

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -269,7 +269,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.comp.spv")),
     })?;
 
-    let compute_pipeline = app.device.create_compute_pipeline(ComputePipelineDescriptor {
+    let compute_pipeline = app.device.create_compute_pipeline(&ComputePipelineDescriptor {
         layout: compute_pipeline_layout,
         compute_stage: PipelineStageDescriptor {
             module: cs,
@@ -278,7 +278,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let render_pipeline = app.device.create_render_pipeline(RenderPipelineDescriptor {
+    let render_pipeline = app.device.create_render_pipeline(&RenderPipelineDescriptor {
         layout: render_pipeline_layout,
         vertex_stage: PipelineStageDescriptor { module: vs, entry_point: Cow::Borrowed("main") },
         fragment_stage: PipelineStageDescriptor { module: fs, entry_point: Cow::Borrowed("main") },

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -186,7 +186,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     app.device.get_queue().submit(&[encoder.finish()?])?;
 
     #[rustfmt::skip]
-    let compute_bind_group_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let compute_bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             BindGroupLayoutBinding {
                 binding: 0,
@@ -226,7 +226,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let render_bind_group_layout = app.device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let render_bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[
             BindGroupLayoutBinding {
                 binding: 0,

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -207,7 +207,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let compute_bind_group = app.device.create_bind_group(BindGroupDescriptor {
+    let compute_bind_group = app.device.create_bind_group(&BindGroupDescriptor {
         layout: compute_bind_group_layout.clone(),
         bindings: vec![
             BindGroupBinding {
@@ -237,7 +237,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     #[rustfmt::skip]
-    let render_bind_group = app.device.create_bind_group(BindGroupDescriptor {
+    let render_bind_group = app.device.create_bind_group(&BindGroupDescriptor {
         layout: render_bind_group_layout.clone(),
         bindings: vec![
             BindGroupBinding {

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -187,7 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let compute_bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             BindGroupLayoutBinding {
                 binding: 0,
                 binding_type: BindingType::StorageTexelBuffer,
@@ -227,7 +227,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[rustfmt::skip]
     let render_bind_group_layout = app.device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[
+        bindings: vec![
             BindGroupLayoutBinding {
                 binding: 0,
                 binding_type: BindingType::UniformBuffer,

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -258,15 +258,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.vert.spv")),
+        code: include_bytes!("shaders/particle_simulator.vert.spv"),
     })?;
 
     let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.frag.spv")),
+        code: include_bytes!("shaders/particle_simulator.frag.spv"),
     })?;
 
     let cs = app.device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.comp.spv")),
+        code: include_bytes!("shaders/particle_simulator.comp.spv"),
     })?;
 
     let compute_pipeline = app.device.create_compute_pipeline(&ComputePipelineDescriptor {

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -257,15 +257,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         push_constant_ranges: vec![],
     })?;
 
-    let vs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let vs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.vert.spv")),
     })?;
 
-    let fs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let fs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.frag.spv")),
     })?;
 
-    let cs = app.device.create_shader_module(ShaderModuleDescriptor {
+    let cs = app.device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/particle_simulator.comp.spv")),
     })?;
 

--- a/examples/particle_simulator.rs
+++ b/examples/particle_simulator.rs
@@ -247,12 +247,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
     })?;
 
-    let compute_pipeline_layout = app.device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let compute_pipeline_layout = app.device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![compute_bind_group_layout],
         push_constant_ranges: vec![],
     })?;
 
-    let render_pipeline_layout = app.device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let render_pipeline_layout = app.device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![render_bind_group_layout],
         push_constant_ranges: vec![],
     })?;

--- a/examples/swapchain.rs
+++ b/examples/swapchain.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let surface = instance.create_surface(&surface_descriptor)?;
 
     let device_desc = DeviceDescriptor::default().with_surface_support(&surface);
-    let device = adapter.create_device(device_desc)?;
+    let device = adapter.create_device(&device_desc)?;
 
     let formats = device.get_supported_swapchain_formats(&surface)?;
     println!("Supported swapchain formats: {:?}", formats);

--- a/examples/swapchain.rs
+++ b/examples/swapchain.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let instance = Instance::new()?;
     let adapter_options = AdapterOptions::default();
-    let adapter = instance.get_adapter(adapter_options)?;
+    let adapter = instance.get_adapter(&adapter_options)?;
     println!("Adapter: {:#?}", adapter.properties());
 
     // The winit_surface_descriptor macro is optional. It creates the platform specific

--- a/examples/swapchain.rs
+++ b/examples/swapchain.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         usage: TextureUsageFlags::OUTPUT_ATTACHMENT,
     };
 
-    let mut swapchain = device.create_swapchain(swapchain_desc, None)?;
+    let mut swapchain = device.create_swapchain(&swapchain_desc, None)?;
 
     window.set_visible(true);
 
@@ -82,7 +82,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // the window is minimized. We do not handle this case here, but it is
                     // handled in the examples framework. Minimizing this window should result
                     // in a validation error.
-                    swapchain = device.create_swapchain(swapchain_desc, Some(&swapchain))?;
+                    swapchain = device.create_swapchain(&swapchain_desc, Some(&swapchain))?;
                 }
                 Event::WindowEvent {
                     event: WindowEvent::RedrawRequested,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }],
     })?;
 
-    let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![bind_group_layout.clone()],
         push_constant_ranges: vec![],
     })?;

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -74,7 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[BindGroupLayoutBinding {
+        bindings: vec![BindGroupLayoutBinding {
             binding: 0,
             visibility: ShaderStageFlags::VERTEX,
             binding_type: BindingType::UniformBuffer,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let uniforms_size_bytes = std::mem::size_of::<Uniforms>();
 
-    let uniform_buffer = device.create_buffer(BufferDescriptor {
+    let uniform_buffer = device.create_buffer(&BufferDescriptor {
         size: uniforms_size_bytes,
         usage: BufferUsageFlags::UNIFORM | BufferUsageFlags::TRANSFER_DST,
     })?;
@@ -139,12 +139,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let vertices_size_bytes = std::mem::size_of::<Vertex>() * vertices.len();
 
-    let vertex_buffer = device.create_buffer(BufferDescriptor {
+    let vertex_buffer = device.create_buffer(&BufferDescriptor {
         size: vertices_size_bytes,
         usage: BufferUsageFlags::VERTEX | BufferUsageFlags::TRANSFER_DST,
     })?;
 
-    let staging_vertex_buffer = device.create_buffer_mapped(BufferDescriptor {
+    let staging_vertex_buffer = device.create_buffer_mapped(&BufferDescriptor {
         size: vertices_size_bytes,
         usage: BufferUsageFlags::TRANSFER_SRC | BufferUsageFlags::MAP_WRITE,
     })?;

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -217,7 +217,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         sample_count: 1,
     };
 
-    let pipeline = device.create_render_pipeline(render_pipeline_descriptor)?;
+    let pipeline = device.create_render_pipeline(&render_pipeline_descriptor)?;
 
     let start = Instant::now();
 

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         time: 0.0,
     };
 
-    let bind_group = device.create_bind_group(BindGroupDescriptor {
+    let bind_group = device.create_bind_group(&BindGroupDescriptor {
         layout: bind_group_layout.clone(),
         bindings: vec![BindGroupBinding {
             binding: 0,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.frag.spv")),
     })?;
 
-    let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[BindGroupLayoutBinding {
             binding: 0,
             visibility: ShaderStageFlags::VERTEX,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let surface = instance.create_surface(&surface_descriptor)?;
 
     let device_desc = DeviceDescriptor::default().with_surface_support(&surface);
-    let device = adapter.create_device(device_desc)?;
+    let device = adapter.create_device(&device_desc)?;
 
     let formats = device.get_supported_swapchain_formats(&surface)?;
     println!("Supported swapchain formats: {:?}", formats);

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -66,11 +66,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     window.set_visible(true);
 
     let vertex_shader = device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/triangle.vert.spv")),
+        code: include_bytes!("shaders/triangle.vert.spv"),
     })?;
 
     let fragment_shader = device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/triangle.frag.spv")),
+        code: include_bytes!("shaders/triangle.frag.spv"),
     })?;
 
     let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -151,7 +151,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     staging_vertex_buffer.copy_from_slice(vertices)?;
 
-    let mut encoder = device.create_command_encoder()?;
+    let mut encoder = device.create_command_encoder(None)?;
 
     encoder.copy_buffer_to_buffer(
         &staging_vertex_buffer.unmap(),
@@ -271,7 +271,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     uniforms.time = (start.elapsed().as_millis() as f32) / 1000.0;
                     uniform_buffer.set_sub_data(0, &[uniforms])?;
 
-                    let mut encoder = device.create_command_encoder()?;
+                    let mut encoder = device.create_command_encoder(None)?;
                     let mut render_pass = encoder.begin_render_pass(RenderPassDescriptor {
                         color_attachments: &[RenderPassColorAttachmentDescriptor {
                             attachment: &frame.view,

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         power_preference: PowerPreference::HighPerformance,
     };
 
-    let adapter = instance.get_adapter(adapter_options)?;
+    let adapter = instance.get_adapter(&adapter_options)?;
     println!("Adapter: {}", adapter.name());
 
     let surface_descriptor = vki::winit_surface_descriptor!(&window);

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -65,11 +65,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut swapchain = device.create_swapchain(&swapchain_desc, None)?;
     window.set_visible(true);
 
-    let vertex_shader = device.create_shader_module(ShaderModuleDescriptor {
+    let vertex_shader = device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.vert.spv")),
     })?;
 
-    let fragment_shader = device.create_shader_module(ShaderModuleDescriptor {
+    let fragment_shader = device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.frag.spv")),
     })?;
 

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         usage: TextureUsageFlags::OUTPUT_ATTACHMENT,
     };
 
-    let mut swapchain = device.create_swapchain(swapchain_desc, None)?;
+    let mut swapchain = device.create_swapchain(&swapchain_desc, None)?;
     window.set_visible(true);
 
     let vertex_shader = device.create_shader_module(ShaderModuleDescriptor {
@@ -243,7 +243,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     event: WindowEvent::Resized(_),
                     ..
                 } => {
-                    swapchain = device.create_swapchain(swapchain_desc, Some(&swapchain))?;
+                    swapchain = device.create_swapchain(&swapchain_desc, Some(&swapchain))?;
                 }
                 Event::WindowEvent {
                     event: WindowEvent::RedrawRequested,

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -149,7 +149,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     staging_vertex_buffer.copy_from_slice(vertices)?;
 
-    let mut encoder = device.create_command_encoder()?;
+    let mut encoder = device.create_command_encoder(None)?;
 
     encoder.copy_buffer_to_buffer(
         &staging_vertex_buffer.unmap(),
@@ -314,7 +314,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     uniforms.time = (start.elapsed().as_millis() as f32) / 1000.0;
                     uniform_buffer.set_sub_data(0, &[uniforms])?;
 
-                    let mut encoder = device.create_command_encoder()?;
+                    let mut encoder = device.create_command_encoder(None)?;
                     let mut render_pass = encoder.begin_render_pass(RenderPassDescriptor {
                         color_attachments: &[RenderPassColorAttachmentDescriptor {
                             attachment: &output_texture_view,

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-        bindings: &[BindGroupLayoutBinding {
+        bindings: vec![BindGroupLayoutBinding {
             binding: 0,
             visibility: ShaderStageFlags::VERTEX,
             binding_type: BindingType::UniformBuffer,

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.frag.spv")),
     })?;
 
-    let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+    let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         bindings: &[BindGroupLayoutBinding {
             binding: 0,
             visibility: ShaderStageFlags::VERTEX,

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -175,7 +175,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     };
 
-    let mut output_texture = device.create_texture(output_texture_descriptor)?;
+    let mut output_texture = device.create_texture(&output_texture_descriptor)?;
     let mut output_texture_view = output_texture.create_default_view()?;
 
     let color_replace = BlendDescriptor {
@@ -281,7 +281,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     if width > 0 && height > 0 {
                         output_texture_descriptor.size.width = width;
                         output_texture_descriptor.size.height = height;
-                        output_texture = device.create_texture(output_texture_descriptor)?;
+                        output_texture = device.create_texture(&output_texture_descriptor)?;
                         output_texture_view = output_texture.create_default_view()?;
                         swapchain = device.create_swapchain(&swapchain_desc, Some(&swapchain))?;
                     }

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let instance = Instance::new()?;
     let adapter_options = AdapterOptions::default();
-    let adapter = instance.get_adapter(adapter_options)?;
+    let adapter = instance.get_adapter(&adapter_options)?;
     println!("Adapter: {}", adapter.name());
 
     let surface_descriptor = vki::winit_surface_descriptor!(&window);

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -232,7 +232,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         sample_count: output_texture_descriptor.sample_count,
     };
 
-    let pipeline = device.create_render_pipeline(render_pipeline_descriptor)?;
+    let pipeline = device.create_render_pipeline(&render_pipeline_descriptor)?;
 
     let start = Instant::now();
 

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let surface = instance.create_surface(&surface_descriptor)?;
 
     let device_desc = DeviceDescriptor::default().with_surface_support(&surface);
-    let device = adapter.create_device(device_desc)?;
+    let device = adapter.create_device(&device_desc)?;
 
     let formats = device.get_supported_swapchain_formats(&surface)?;
     println!("Supported swapchain formats: {:?}", formats);

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -64,11 +64,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut swapchain = device.create_swapchain(&swapchain_desc, None)?;
 
     let vertex_shader = device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/triangle.vert.spv")),
+        code: include_bytes!("shaders/triangle.vert.spv"),
     })?;
 
     let fragment_shader = device.create_shader_module(&ShaderModuleDescriptor {
-        code: Cow::Borrowed(include_bytes!("shaders/triangle.frag.spv")),
+        code: include_bytes!("shaders/triangle.frag.spv"),
     })?;
 
     let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -93,7 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let uniforms_size_bytes = std::mem::size_of::<Uniforms>();
 
-    let uniform_buffer = device.create_buffer(BufferDescriptor {
+    let uniform_buffer = device.create_buffer(&BufferDescriptor {
         size: uniforms_size_bytes,
         usage: BufferUsageFlags::UNIFORM | BufferUsageFlags::TRANSFER_DST,
     })?;
@@ -137,12 +137,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let vertices_size_bytes = std::mem::size_of::<Vertex>() * vertices.len();
 
-    let vertex_buffer = device.create_buffer(BufferDescriptor {
+    let vertex_buffer = device.create_buffer(&BufferDescriptor {
         size: vertices_size_bytes,
         usage: BufferUsageFlags::VERTEX | BufferUsageFlags::TRANSFER_DST,
     })?;
 
-    let staging_vertex_buffer = device.create_buffer_mapped(BufferDescriptor {
+    let staging_vertex_buffer = device.create_buffer_mapped(&BufferDescriptor {
         size: vertices_size_bytes,
         usage: BufferUsageFlags::TRANSFER_SRC | BufferUsageFlags::MAP_WRITE,
     })?;

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         time: 0.0,
     };
 
-    let bind_group = device.create_bind_group(BindGroupDescriptor {
+    let bind_group = device.create_bind_group(&BindGroupDescriptor {
         layout: bind_group_layout.clone(),
         bindings: vec![BindGroupBinding {
             binding: 0,

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }],
     })?;
 
-    let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
         bind_group_layouts: vec![bind_group_layout.clone()],
         push_constant_ranges: vec![],
     })?;

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         usage: TextureUsageFlags::OUTPUT_ATTACHMENT,
     };
 
-    let mut swapchain = device.create_swapchain(swapchain_desc, None)?;
+    let mut swapchain = device.create_swapchain(&swapchain_desc, None)?;
 
     let vertex_shader = device.create_shader_module(ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.vert.spv")),
@@ -283,7 +283,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         output_texture_descriptor.size.height = height;
                         output_texture = device.create_texture(output_texture_descriptor)?;
                         output_texture_view = output_texture.create_default_view()?;
-                        swapchain = device.create_swapchain(swapchain_desc, Some(&swapchain))?;
+                        swapchain = device.create_swapchain(&swapchain_desc, Some(&swapchain))?;
                     }
                 }
                 Event::WindowEvent {

--- a/examples/triangle_multisample.rs
+++ b/examples/triangle_multisample.rs
@@ -63,11 +63,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut swapchain = device.create_swapchain(&swapchain_desc, None)?;
 
-    let vertex_shader = device.create_shader_module(ShaderModuleDescriptor {
+    let vertex_shader = device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.vert.spv")),
     })?;
 
-    let fragment_shader = device.create_shader_module(ShaderModuleDescriptor {
+    let fragment_shader = device.create_shader_module(&ShaderModuleDescriptor {
         code: Cow::Borrowed(include_bytes!("shaders/triangle.frag.spv")),
     })?;
 

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -170,7 +170,7 @@ impl<T: 'static> App<T> {
                 Ok(_) | Err(_) => PowerPreference::HighPerformance,
             },
         })?;
-        let device = adapter.create_device(DeviceDescriptor {
+        let device = adapter.create_device(&DeviceDescriptor {
             surface_support: Some(&surface),
             extensions: Extensions {
                 anisotropic_filtering: false,

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -164,7 +164,7 @@ impl<T: 'static> App<T> {
         })?;
 
         let surface = instance.create_surface(&vki::winit_surface_descriptor!(&window))?;
-        let adapter = instance.get_adapter(AdapterOptions {
+        let adapter = instance.get_adapter(&AdapterOptions {
             power_preference: match std::env::var("LOW_POWER").as_ref().map(|s| s.as_str()) {
                 Ok("1") | Ok("true") => PowerPreference::LowPower,
                 Ok(_) | Err(_) => PowerPreference::HighPerformance,

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -392,11 +392,11 @@ pub fn create_buffer_with_data<U: Copy + 'static>(
     };
 
     if is_write_mapped {
-        let mapped_buffer = device.create_buffer_mapped(descriptor)?;
+        let mapped_buffer = device.create_buffer_mapped(&descriptor)?;
         mapped_buffer.copy_from_slice(data)?;
         Ok(mapped_buffer.unmap())
     } else {
-        let buffer = device.create_buffer(descriptor)?;
+        let buffer = device.create_buffer(&descriptor)?;
         copy_to_buffer(device, encoder, data, &buffer)?;
         Ok(buffer)
     }
@@ -407,7 +407,7 @@ pub fn create_staging_buffer<U: Copy + 'static>(device: &Device, data: &[U]) -> 
         usage: BufferUsageFlags::MAP_WRITE | BufferUsageFlags::TRANSFER_SRC,
         size: byte_length(data),
     };
-    let mapped_buffer = device.create_buffer_mapped(descriptor)?;
+    let mapped_buffer = device.create_buffer_mapped(&descriptor)?;
     mapped_buffer.copy_from_slice(data)?;
     Ok(mapped_buffer.unmap())
 }

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -368,7 +368,7 @@ impl<T: 'static> App<T> {
 /// Convenience function for submitting a command buffer and creating a new encoder
 pub fn submit(device: &Device, encoder: CommandEncoder) -> Result<CommandEncoder, vki::Error> {
     device.get_queue().submit(&[encoder.finish()?])?;
-    Ok(device.create_command_encoder()?)
+    Ok(device.create_command_encoder(None)?)
 }
 
 /// Creates a new buffer with the given data. If the `usage` flag contains `BufferUsageFlags::MAP_WRITE`,

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -47,7 +47,7 @@ fn create_swapchain_and_depth_view_and_color_view(
             vk::Result::ERROR_INITIALIZATION_FAILED
         })?;
 
-    let depth_texture = device.create_texture(TextureDescriptor {
+    let depth_texture = device.create_texture(&TextureDescriptor {
         size: Extent3D {
             width,
             height,
@@ -63,7 +63,7 @@ fn create_swapchain_and_depth_view_and_color_view(
 
     let depth_view = depth_texture.create_default_view()?;
 
-    let color_texture = device.create_texture(TextureDescriptor {
+    let color_texture = device.create_texture(&TextureDescriptor {
         size: Extent3D {
             width,
             height,
@@ -456,7 +456,7 @@ pub fn create_texture_with_data(
         dimension: TextureDimension::D2,
     };
 
-    let texture = device.create_texture(descriptor)?;
+    let texture = device.create_texture(&descriptor)?;
 
     let buffer = create_staging_buffer(&device, data)?;
 

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -35,7 +35,7 @@ fn create_swapchain_and_depth_view_and_color_view(
 ) -> Result<(Swapchain, TextureView, TextureView), Error> {
     let swap_chain = device
         .create_swapchain(
-            SwapchainDescriptor {
+            &SwapchainDescriptor {
                 surface,
                 usage: TextureUsageFlags::OUTPUT_ATTACHMENT,
                 format: DEFAULT_COLOR_FORMAT,

--- a/src/imp/adapter.rs
+++ b/src/imp/adapter.rs
@@ -23,7 +23,7 @@ impl Adapter {
         self.inner.properties()
     }
 
-    pub fn create_device(&self, descriptor: DeviceDescriptor) -> Result<Device, Error> {
+    pub fn create_device(&self, descriptor: &DeviceDescriptor) -> Result<Device, Error> {
         let device = DeviceInner::new(self.inner.clone(), descriptor)?;
         Ok(device.into())
     }

--- a/src/imp/binding.rs
+++ b/src/imp/binding.rs
@@ -100,7 +100,7 @@ pub fn find_layout_binding(
 }
 
 impl BindGroupInner {
-    pub fn new(descriptor: BindGroupDescriptor) -> Result<BindGroupInner, Error> {
+    pub fn new(descriptor: &BindGroupDescriptor) -> Result<BindGroupInner, Error> {
         // TODO: DescriptorPool management. Dawn specifically calls out that this is inefficient
 
         let device = Arc::clone(&descriptor.layout.inner.device);

--- a/src/imp/buffer.rs
+++ b/src/imp/buffer.rs
@@ -165,7 +165,7 @@ pub fn access_flags(usage: BufferUsageFlags) -> vk::AccessFlags {
 }
 
 impl BufferInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: BufferDescriptor) -> Result<BufferInner, Error> {
+    pub fn new(device: Arc<DeviceInner>, descriptor: &BufferDescriptor) -> Result<BufferInner, Error> {
         let create_info = vk::BufferCreateInfo {
             size: descriptor.size as u64,
             usage: usage_flags(descriptor.usage),
@@ -212,7 +212,7 @@ impl BufferInner {
         drop(state);
 
         Ok(BufferInner {
-            descriptor,
+            descriptor: *descriptor,
             allocation,
             allocation_info,
             device,

--- a/src/imp/buffer.rs
+++ b/src/imp/buffer.rs
@@ -165,7 +165,7 @@ pub fn access_flags(usage: BufferUsageFlags) -> vk::AccessFlags {
 }
 
 impl BufferInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: &BufferDescriptor) -> Result<BufferInner, Error> {
+    pub fn new(device: Arc<DeviceInner>, descriptor: BufferDescriptor) -> Result<BufferInner, Error> {
         let create_info = vk::BufferCreateInfo {
             size: descriptor.size as u64,
             usage: usage_flags(descriptor.usage),
@@ -212,7 +212,7 @@ impl BufferInner {
         drop(state);
 
         Ok(BufferInner {
-            descriptor: *descriptor,
+            descriptor,
             allocation,
             allocation_info,
             device,

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -166,7 +166,7 @@ impl Device {
 }
 
 impl DeviceInner {
-    pub fn new(adapter: Arc<AdapterInner>, descriptor: DeviceDescriptor) -> Result<DeviceInner, Error> {
+    pub fn new(adapter: Arc<AdapterInner>, descriptor: &DeviceDescriptor) -> Result<DeviceInner, Error> {
         let extension_names = if descriptor.surface_support.is_some() {
             vec![c_str!("VK_KHR_swapchain")]
         } else {

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -124,8 +124,8 @@ impl Device {
         Ok(sampler.into())
     }
 
-    pub fn create_bind_group_layout(&self, descriptor: BindGroupLayoutDescriptor) -> Result<BindGroupLayout, Error> {
-        let bind_group_layout = BindGroupLayoutInner::new(self.inner.clone(), descriptor)?;
+    pub fn create_bind_group_layout(&self, descriptor: &BindGroupLayoutDescriptor) -> Result<BindGroupLayout, Error> {
+        let bind_group_layout = BindGroupLayoutInner::new(self.inner.clone(), *descriptor)?;
         Ok(bind_group_layout.into())
     }
 

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -145,12 +145,12 @@ impl Device {
         Ok(pipeline_layout.into())
     }
 
-    pub fn create_compute_pipeline(&self, descriptor: ComputePipelineDescriptor) -> Result<ComputePipeline, Error> {
+    pub fn create_compute_pipeline(&self, descriptor: &ComputePipelineDescriptor) -> Result<ComputePipeline, Error> {
         let compute_pipeline = ComputePipelineInner::new(self.inner.clone(), descriptor)?;
         Ok(compute_pipeline.into())
     }
 
-    pub fn create_render_pipeline(&self, descriptor: RenderPipelineDescriptor) -> Result<RenderPipeline, Error> {
+    pub fn create_render_pipeline(&self, descriptor: &RenderPipelineDescriptor) -> Result<RenderPipeline, Error> {
         let render_pipeline = RenderPipelineInner::new(self.inner.clone(), descriptor)?;
         Ok(render_pipeline.into())
     }

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -125,7 +125,8 @@ impl Device {
     }
 
     pub fn create_bind_group_layout(&self, descriptor: &BindGroupLayoutDescriptor) -> Result<BindGroupLayout, Error> {
-        let bind_group_layout = BindGroupLayoutInner::new(self.inner.clone(), *descriptor)?;
+        let descriptor = descriptor.clone();
+        let bind_group_layout = BindGroupLayoutInner::new(self.inner.clone(), descriptor)?;
         Ok(bind_group_layout.into())
     }
 

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -19,9 +19,9 @@ use crate::imp::{
 
 use crate::{
     Adapter, BindGroup, BindGroupDescriptor, BindGroupLayout, BindGroupLayoutDescriptor, Buffer, BufferDescriptor,
-    CommandEncoder, ComputePipeline, ComputePipelineDescriptor, Device, DeviceDescriptor, Limits, MappedBuffer,
-    PipelineLayout, PipelineLayoutDescriptor, Queue, RenderPipeline, RenderPipelineDescriptor, Sampler,
-    SamplerDescriptor, ShaderModule, ShaderModuleDescriptor, Surface, Swapchain, SwapchainDescriptor, Texture,
+    CommandEncoder, CommandEncoderDescriptor, ComputePipeline, ComputePipelineDescriptor, Device, DeviceDescriptor,
+    Limits, MappedBuffer, PipelineLayout, PipelineLayoutDescriptor, Queue, RenderPipeline, RenderPipelineDescriptor,
+    Sampler, SamplerDescriptor, ShaderModule, ShaderModuleDescriptor, Surface, Swapchain, SwapchainDescriptor, Texture,
     TextureDescriptor, TextureFormat,
 };
 
@@ -154,7 +154,10 @@ impl Device {
         Ok(render_pipeline.into())
     }
 
-    pub fn create_command_encoder(&self) -> Result<CommandEncoder, Error> {
+    pub fn create_command_encoder(
+        &self,
+        _descriptor: Option<&CommandEncoderDescriptor>,
+    ) -> Result<CommandEncoder, Error> {
         let command_encoder = CommandEncoderInner::new(self.inner.clone())?;
         Ok(command_encoder.into())
     }

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -114,7 +114,7 @@ impl Device {
         })
     }
 
-    pub fn create_texture(&self, descriptor: TextureDescriptor) -> Result<Texture, Error> {
+    pub fn create_texture(&self, descriptor: &TextureDescriptor) -> Result<Texture, Error> {
         let texture = TextureInner::new(self.inner.clone(), descriptor)?;
         Ok(texture.into())
     }

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -139,7 +139,8 @@ impl Device {
         Ok(shader_module.into())
     }
 
-    pub fn create_pipeline_layout(&self, descriptor: PipelineLayoutDescriptor) -> Result<PipelineLayout, Error> {
+    pub fn create_pipeline_layout(&self, descriptor: &PipelineLayoutDescriptor) -> Result<PipelineLayout, Error> {
+        let descriptor = descriptor.clone();
         let pipeline_layout = PipelineLayoutInner::new(self.inner.clone(), descriptor)?;
         Ok(pipeline_layout.into())
     }

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -61,7 +61,7 @@ struct CommandPoolAndBuffer {
 impl Device {
     pub fn create_swapchain(
         &self,
-        descriptor: SwapchainDescriptor,
+        descriptor: &SwapchainDescriptor,
         old_swapchain: Option<&Swapchain>,
     ) -> Result<Swapchain, Error> {
         let swapchain = SwapchainInner::new(self.inner.clone(), descriptor, old_swapchain.map(|s| &*s.inner))?;

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -134,7 +134,7 @@ impl Device {
         Ok(bind_group.into())
     }
 
-    pub fn create_shader_module(&self, descriptor: ShaderModuleDescriptor) -> Result<ShaderModule, Error> {
+    pub fn create_shader_module(&self, descriptor: &ShaderModuleDescriptor) -> Result<ShaderModule, Error> {
         let shader_module = ShaderModuleInner::new(self.inner.clone(), descriptor)?;
         Ok(shader_module.into())
     }

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -130,7 +130,7 @@ impl Device {
         Ok(bind_group_layout.into())
     }
 
-    pub fn create_bind_group(&self, descriptor: BindGroupDescriptor) -> Result<BindGroup, Error> {
+    pub fn create_bind_group(&self, descriptor: &BindGroupDescriptor) -> Result<BindGroup, Error> {
         let bind_group = BindGroupInner::new(descriptor)?;
         Ok(bind_group.into())
     }

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -101,12 +101,12 @@ impl Device {
     }
 
     pub fn create_buffer(&self, descriptor: &BufferDescriptor) -> Result<Buffer, Error> {
-        let buffer = BufferInner::new(self.inner.clone(), descriptor)?;
+        let buffer = BufferInner::new(self.inner.clone(), *descriptor)?;
         Ok(buffer.into())
     }
 
     pub fn create_buffer_mapped(&self, descriptor: &BufferDescriptor) -> Result<MappedBuffer, Error> {
-        let buffer = BufferInner::new(self.inner.clone(), descriptor)?;
+        let buffer = BufferInner::new(self.inner.clone(), *descriptor)?;
         let data = unsafe { buffer.get_mapped_ptr()? };
         Ok(MappedBuffer {
             inner: Arc::new(buffer),
@@ -115,12 +115,12 @@ impl Device {
     }
 
     pub fn create_texture(&self, descriptor: &TextureDescriptor) -> Result<Texture, Error> {
-        let texture = TextureInner::new(self.inner.clone(), descriptor)?;
+        let texture = TextureInner::new(self.inner.clone(), *descriptor)?;
         Ok(texture.into())
     }
 
-    pub fn create_sampler(&self, descriptor: SamplerDescriptor) -> Result<Sampler, Error> {
-        let sampler = SamplerInner::new(self.inner.clone(), descriptor)?;
+    pub fn create_sampler(&self, descriptor: &SamplerDescriptor) -> Result<Sampler, Error> {
+        let sampler = SamplerInner::new(self.inner.clone(), *descriptor)?;
         Ok(sampler.into())
     }
 

--- a/src/imp/device.rs
+++ b/src/imp/device.rs
@@ -100,12 +100,12 @@ impl Device {
         }
     }
 
-    pub fn create_buffer(&self, descriptor: BufferDescriptor) -> Result<Buffer, Error> {
+    pub fn create_buffer(&self, descriptor: &BufferDescriptor) -> Result<Buffer, Error> {
         let buffer = BufferInner::new(self.inner.clone(), descriptor)?;
         Ok(buffer.into())
     }
 
-    pub fn create_buffer_mapped(&self, descriptor: BufferDescriptor) -> Result<MappedBuffer, Error> {
+    pub fn create_buffer_mapped(&self, descriptor: &BufferDescriptor) -> Result<MappedBuffer, Error> {
         let buffer = BufferInner::new(self.inner.clone(), descriptor)?;
         let data = unsafe { buffer.get_mapped_ptr()? };
         Ok(MappedBuffer {

--- a/src/imp/instance.rs
+++ b/src/imp/instance.rs
@@ -35,9 +35,9 @@ impl Instance {
         Ok(inner.into())
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn get_adapter(&self, options: &AdapterOptions) -> Result<Adapter, Error> {
-        let options = options.clone();
-        let adapter = AdapterInner::new(self.inner.clone(), options)?;
+        let adapter = AdapterInner::new(self.inner.clone(), *options)?;
         Ok(adapter.into())
     }
 

--- a/src/imp/instance.rs
+++ b/src/imp/instance.rs
@@ -35,7 +35,8 @@ impl Instance {
         Ok(inner.into())
     }
 
-    pub fn get_adapter(&self, options: AdapterOptions) -> Result<Adapter, Error> {
+    pub fn get_adapter(&self, options: &AdapterOptions) -> Result<Adapter, Error> {
+        let options = options.clone();
         let adapter = AdapterInner::new(self.inner.clone(), options)?;
         Ok(adapter.into())
     }

--- a/src/imp/pipeline.rs
+++ b/src/imp/pipeline.rs
@@ -68,7 +68,10 @@ impl Drop for PipelineLayoutInner {
 }
 
 impl ComputePipelineInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: ComputePipelineDescriptor) -> Result<ComputePipelineInner, Error> {
+    pub fn new(
+        device: Arc<DeviceInner>,
+        descriptor: &ComputePipelineDescriptor,
+    ) -> Result<ComputePipelineInner, Error> {
         // TODO: inspect push constants
 
         let entry_point = CString::new(&*descriptor.compute_stage.entry_point).map_err(|e| {
@@ -394,7 +397,7 @@ pub fn vertex_input_binding_description(descriptor: &VertexBufferDescriptor) -> 
 }
 
 impl RenderPipelineInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: RenderPipelineDescriptor) -> Result<RenderPipelineInner, Error> {
+    pub fn new(device: Arc<DeviceInner>, descriptor: &RenderPipelineDescriptor) -> Result<RenderPipelineInner, Error> {
         // TODO: inspect push constants
 
         let vertex_entry_point = CString::new(&*descriptor.vertex_stage.entry_point).map_err(|e| {

--- a/src/imp/shader.rs
+++ b/src/imp/shader.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::{mem, ptr};
 
 impl ShaderModuleInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: ShaderModuleDescriptor) -> Result<ShaderModuleInner, Error> {
+    pub fn new(device: Arc<DeviceInner>, descriptor: &ShaderModuleDescriptor) -> Result<ShaderModuleInner, Error> {
         // TODO: Use spirv-cross to reflect binding and attribute info so we can determine
         //       when a shader module is compatible with a given pipeline layout
 

--- a/src/imp/swapchain.rs
+++ b/src/imp/swapchain.rs
@@ -41,7 +41,7 @@ impl SwapchainInner {
     /// Recipe: _Creating a swapchain_ (page `105`)
     pub fn new(
         device: Arc<DeviceInner>,
-        descriptor: SwapchainDescriptor,
+        descriptor: &SwapchainDescriptor,
         old_swapchain: Option<&SwapchainInner>,
     ) -> Result<SwapchainInner, Error> {
         unsafe {

--- a/src/imp/texture.rs
+++ b/src/imp/texture.rs
@@ -350,7 +350,7 @@ impl Texture {
 }
 
 impl TextureInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: TextureDescriptor) -> Result<TextureInner, Error> {
+    pub fn new(device: Arc<DeviceInner>, descriptor: &TextureDescriptor) -> Result<TextureInner, Error> {
         let flags = if descriptor.array_layer_count >= 6 && descriptor.size.width == descriptor.size.height {
             vk::ImageCreateFlags::CUBE_COMPATIBLE
         } else {
@@ -423,7 +423,7 @@ impl TextureInner {
             device: device.clone(),
             allocation: Some(allocation),
             allocation_info: Some(allocation_info),
-            descriptor,
+            descriptor: *descriptor,
             subresource_usage: Mutex::new(subresource_usage),
         })
     }

--- a/src/imp/texture.rs
+++ b/src/imp/texture.rs
@@ -350,7 +350,7 @@ impl Texture {
 }
 
 impl TextureInner {
-    pub fn new(device: Arc<DeviceInner>, descriptor: &TextureDescriptor) -> Result<TextureInner, Error> {
+    pub fn new(device: Arc<DeviceInner>, descriptor: TextureDescriptor) -> Result<TextureInner, Error> {
         let flags = if descriptor.array_layer_count >= 6 && descriptor.size.width == descriptor.size.height {
             vk::ImageCreateFlags::CUBE_COMPATIBLE
         } else {
@@ -423,7 +423,7 @@ impl TextureInner {
             device: device.clone(),
             allocation: Some(allocation),
             allocation_info: Some(allocation_info),
-            descriptor: *descriptor,
+            descriptor,
             subresource_usage: Mutex::new(subresource_usage),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,8 +675,8 @@ pub struct DepthStencilStateDescriptor {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ShaderModuleDescriptor {
-    pub code: Cow<'static, [u8]>,
+pub struct ShaderModuleDescriptor<'a> {
+    pub code: &'a [u8],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -894,6 +894,7 @@ pub struct CommandBuffer {
     inner: imp::CommandBufferInner,
 }
 
+#[derive(Clone, Default, Debug, PartialEq)]
 pub struct CommandEncoderDescriptor {}
 
 /// Specifies buffer to texture copy operation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,9 +449,9 @@ pub struct BindGroupLayoutBinding {
     pub binding_type: BindingType,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct BindGroupLayoutDescriptor<'a> {
-    pub bindings: &'a [BindGroupLayoutBinding],
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BindGroupLayoutDescriptor {
+    pub bindings: Vec<BindGroupLayoutBinding>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/tests/binding.rs
+++ b/tests/binding.rs
@@ -19,7 +19,7 @@ fn create_bind_group_layout() {
             }],
         };
 
-        let _bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let _bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         Ok(instance)
     });
@@ -90,7 +90,7 @@ fn create_bind_group() {
                 },
             ],
         };
-        let bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         let bind_group_descriptor = BindGroupDescriptor {
             layout: bind_group_layout,

--- a/tests/binding.rs
+++ b/tests/binding.rs
@@ -48,7 +48,7 @@ fn create_bind_group() {
         })?;
 
         let sampler_descriptor = SamplerDescriptor::default();
-        let sampler = device.create_sampler(sampler_descriptor)?;
+        let sampler = device.create_sampler(&sampler_descriptor)?;
 
         let texture_descriptor = TextureDescriptor {
             size: Extent3D {

--- a/tests/binding.rs
+++ b/tests/binding.rs
@@ -34,13 +34,13 @@ fn create_bind_group() {
             usage: BufferUsageFlags::UNIFORM | BufferUsageFlags::TRANSFER_DST,
             size: 1024,
         };
-        let buffer = device.create_buffer(buffer_descriptor)?;
+        let buffer = device.create_buffer(&buffer_descriptor)?;
 
         let texel_buffer_descriptor = BufferDescriptor {
             usage: BufferUsageFlags::STORAGE,
             size: 1024,
         };
-        let texel_buffer = device.create_buffer(texel_buffer_descriptor)?;
+        let texel_buffer = device.create_buffer(&texel_buffer_descriptor)?;
         let texel_buffer_view = texel_buffer.create_view(BufferViewDescriptor {
             format: BufferViewFormat::Texture(TextureFormat::R8G8B8A8Unorm),
             size: 1024,

--- a/tests/binding.rs
+++ b/tests/binding.rs
@@ -63,7 +63,7 @@ fn create_bind_group() {
             sample_count: 1,
             usage: TextureUsageFlags::SAMPLED,
         };
-        let texture = device.create_texture(texture_descriptor)?;
+        let texture = device.create_texture(&texture_descriptor)?;
         let texture_view = texture.create_default_view()?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {

--- a/tests/binding.rs
+++ b/tests/binding.rs
@@ -12,7 +12,7 @@ fn create_bind_group_layout() {
         let (instance, _adapter, device) = support::init()?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[BindGroupLayoutBinding {
+            bindings: vec![BindGroupLayoutBinding {
                 binding: 0,
                 visibility: ShaderStageFlags::VERTEX,
                 binding_type: BindingType::UniformBuffer,
@@ -67,7 +67,7 @@ fn create_bind_group() {
         let texture_view = texture.create_default_view()?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::VERTEX,

--- a/tests/binding.rs
+++ b/tests/binding.rs
@@ -113,7 +113,7 @@ fn create_bind_group() {
                 },
             ],
         };
-        let _bind_group = device.create_bind_group(bind_group_descriptor)?;
+        let _bind_group = device.create_bind_group(&bind_group_descriptor)?;
 
         Ok(instance)
     });

--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -90,7 +90,7 @@ fn create_buffer_mapped() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let data: &[u32] = &[1, 2, 3, 4, 5];
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
@@ -132,7 +132,7 @@ fn create_buffer_mapped_write_data() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let data: &[u32] = &[1, 2, 3, 4, 5];
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
@@ -197,7 +197,7 @@ fn set_sub_data() {
 
         let queue = device.get_queue();
 
-        let encoder = device.create_command_encoder()?;
+        let encoder = device.create_command_encoder(None)?;
 
         queue.submit(&[encoder.finish()?])?;
 
@@ -233,7 +233,7 @@ fn set_sub_data_offset() {
 
         let queue = device.get_queue();
 
-        let encoder = device.create_command_encoder()?;
+        let encoder = device.create_command_encoder(None)?;
 
         queue.submit(&[encoder.finish()?])?;
 

--- a/tests/buffer.rs
+++ b/tests/buffer.rs
@@ -13,7 +13,7 @@ fn create_buffer_vertex_transfer_dst() {
             size: 1024,
         };
 
-        let _buffer = device.create_buffer(descriptor)?;
+        let _buffer = device.create_buffer(&descriptor)?;
 
         Ok(instance)
     });
@@ -29,7 +29,7 @@ fn create_buffer_uniform_mapped_write() {
             size: 1024,
         };
 
-        let _buffer = device.create_buffer(descriptor)?;
+        let _buffer = device.create_buffer(&descriptor)?;
 
         Ok(instance)
     });
@@ -45,7 +45,7 @@ fn create_buffer_write_staging() {
             size: 1024,
         };
 
-        let _buffer = device.create_buffer(descriptor)?;
+        let _buffer = device.create_buffer(&descriptor)?;
 
         Ok(instance)
     });
@@ -61,7 +61,7 @@ fn create_buffer_read_staging() {
             size: 1024,
         };
 
-        let _buffer = device.create_buffer(descriptor)?;
+        let _buffer = device.create_buffer(&descriptor)?;
 
         Ok(instance)
     });
@@ -77,7 +77,7 @@ fn create_buffer_read_storage() {
             size: 1024,
         };
 
-        let _buffer = device.create_buffer(descriptor)?;
+        let _buffer = device.create_buffer(&descriptor)?;
 
         drop(_buffer);
 
@@ -96,14 +96,14 @@ fn create_buffer_mapped() {
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
         let data_byte_size = data_byte_size;
 
-        let write_buffer_mapped = device.create_buffer_mapped(BufferDescriptor {
+        let write_buffer_mapped = device.create_buffer_mapped(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_WRITE | BufferUsageFlags::TRANSFER_SRC,
             size: data_byte_size,
         })?;
 
         write_buffer_mapped.copy_from_slice(data)?;
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST,
             size: data_byte_size,
         })?;
@@ -138,7 +138,7 @@ fn create_buffer_mapped_write_data() {
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
         let data_byte_size = data_byte_size;
 
-        let mut write_buffer_mapped = device.create_buffer_mapped(BufferDescriptor {
+        let mut write_buffer_mapped = device.create_buffer_mapped(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_WRITE | BufferUsageFlags::TRANSFER_SRC,
             size: data_byte_size,
         })?;
@@ -150,7 +150,7 @@ fn create_buffer_mapped_write_data() {
 
         write_data.flush()?;
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST,
             size: data_byte_size,
         })?;
@@ -182,7 +182,7 @@ fn set_sub_data() {
         let data: &[u32] = &[1, 2, 3, 4];
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST,
             size: data_byte_size,
         })?;
@@ -223,7 +223,7 @@ fn set_sub_data_offset() {
         let data: &[u32] = &[1, 2, 3, 4];
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST,
             size: (2 * data_byte_size) as _,
         })?;
@@ -264,7 +264,7 @@ fn mapping_twice_should_fail() {
         let data: &[u32] = &[1, 2, 3, 4];
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
 
-        let buffer = device.create_buffer(BufferDescriptor {
+        let buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST,
             size: data_byte_size,
         })?;

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -40,7 +40,7 @@ fn copy_buffer_with_compute_shader() {
             push_constant_ranges: vec![],
         })?;
 
-        let pipeline = device.create_compute_pipeline(ComputePipelineDescriptor {
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
             compute_stage: PipelineStageDescriptor {
                 entry_point: Cow::Borrowed("main"),
                 module: compute_module,
@@ -138,7 +138,7 @@ fn push_constants() {
             }],
         })?;
 
-        let pipeline = device.create_compute_pipeline(ComputePipelineDescriptor {
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
             compute_stage: PipelineStageDescriptor {
                 entry_point: Cow::Borrowed("main"),
                 module: compute_module,
@@ -249,7 +249,7 @@ fn dispatch_indirect() {
             push_constant_ranges: vec![],
         })?;
 
-        let pipeline = device.create_compute_pipeline(ComputePipelineDescriptor {
+        let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
             compute_stage: PipelineStageDescriptor {
                 entry_point: Cow::Borrowed("main"),
                 module: compute_module,

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -59,14 +59,14 @@ fn copy_buffer_with_compute_shader() {
         let data_byte_size = std::mem::size_of::<[f32; 4]>() * data.len();
         let data_byte_size = data_byte_size;
 
-        let write_buffer_mapped = device.create_buffer_mapped(BufferDescriptor {
+        let write_buffer_mapped = device.create_buffer_mapped(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_WRITE | BufferUsageFlags::TRANSFER_SRC | BufferUsageFlags::STORAGE,
             size: data_byte_size,
         })?;
 
         write_buffer_mapped.copy_from_slice(data)?;
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST | BufferUsageFlags::STORAGE,
             size: data_byte_size,
         })?;
@@ -148,7 +148,7 @@ fn push_constants() {
 
         let mut encoder = device.create_command_encoder()?;
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST | BufferUsageFlags::STORAGE,
             size: data_byte_size,
         })?;
@@ -268,14 +268,14 @@ fn dispatch_indirect() {
         let data_byte_size = std::mem::size_of::<[f32; 4]>() * data.len();
         let data_byte_size = data_byte_size;
 
-        let write_buffer_mapped = device.create_buffer_mapped(BufferDescriptor {
+        let write_buffer_mapped = device.create_buffer_mapped(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_WRITE | BufferUsageFlags::TRANSFER_SRC | BufferUsageFlags::STORAGE,
             size: data_byte_size,
         })?;
 
         write_buffer_mapped.copy_from_slice(data)?;
 
-        let read_buffer = device.create_buffer(BufferDescriptor {
+        let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST | BufferUsageFlags::STORAGE,
             size: data_byte_size,
         })?;
@@ -294,7 +294,7 @@ fn dispatch_indirect() {
             ],
         })?;
 
-        let indirect_buffer = device.create_buffer(BufferDescriptor {
+        let indirect_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::INDIRECT | BufferUsageFlags::TRANSFER_DST,
             size: std::mem::size_of::<DispatchIndirectCommand>(),
         })?;

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -21,7 +21,7 @@ fn copy_buffer_with_compute_shader() {
         })?;
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::COMPUTE,
@@ -122,7 +122,7 @@ fn push_constants() {
         })?;
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            bindings: &[BindGroupLayoutBinding {
+            bindings: vec![BindGroupLayoutBinding {
                 binding: 0,
                 visibility: ShaderStageFlags::COMPUTE,
                 binding_type: BindingType::StorageBuffer,
@@ -230,7 +230,7 @@ fn dispatch_indirect() {
         })?;
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::COMPUTE,

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -15,9 +15,7 @@ fn copy_buffer_with_compute_shader() {
         let (instance, _adapter, device) = support::init()?;
 
         let compute_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!(
-                "shaders/command_buffer.copy_buffer_with_compute_shader.comp.spv"
-            )),
+            code: include_bytes!("shaders/command_buffer.copy_buffer_with_compute_shader.comp.spv"),
         })?;
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
@@ -118,7 +116,7 @@ fn push_constants() {
         let data_byte_size = data_byte_size;
 
         let compute_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/command_buffer.push_constants.comp.spv")),
+            code: include_bytes!("shaders/command_buffer.push_constants.comp.spv"),
         })?;
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
@@ -224,9 +222,7 @@ fn dispatch_indirect() {
         let (instance, _adapter, device) = support::init()?;
 
         let compute_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!(
-                "shaders/command_buffer.copy_buffer_with_compute_shader.comp.spv"
-            )),
+            code: include_bytes!("shaders/command_buffer.copy_buffer_with_compute_shader.comp.spv"),
         })?;
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -71,7 +71,7 @@ fn copy_buffer_with_compute_shader() {
             size: data_byte_size,
         })?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout,
             bindings: vec![
                 BindGroupBinding {
@@ -153,7 +153,7 @@ fn push_constants() {
             size: data_byte_size,
         })?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout,
             bindings: vec![BindGroupBinding {
                 binding: 0,
@@ -280,7 +280,7 @@ fn dispatch_indirect() {
             size: data_byte_size,
         })?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout,
             bindings: vec![
                 BindGroupBinding {

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -48,7 +48,7 @@ fn copy_buffer_with_compute_shader() {
             layout: pipeline_layout,
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let data: &[[f32; 4]] = &[
             [1.0, 2.0, 3.0, 4.0],
@@ -146,7 +146,7 @@ fn push_constants() {
             layout: pipeline_layout,
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let read_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::MAP_READ | BufferUsageFlags::TRANSFER_DST | BufferUsageFlags::STORAGE,
@@ -191,7 +191,7 @@ fn debug_markers() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
         encoder.push_debug_group("push_debug_group");
         encoder.insert_debug_marker("insert_debug_marker");
         encoder.pop_debug_group();
@@ -257,7 +257,7 @@ fn dispatch_indirect() {
             layout: pipeline_layout,
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let data: &[[f32; 4]] = &[
             [1.0, 2.0, 3.0, 4.0],

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -14,7 +14,7 @@ fn copy_buffer_with_compute_shader() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let compute_module = device.create_shader_module(ShaderModuleDescriptor {
+        let compute_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!(
                 "shaders/command_buffer.copy_buffer_with_compute_shader.comp.spv"
             )),
@@ -117,7 +117,7 @@ fn push_constants() {
         let data_byte_size = std::mem::size_of::<u32>() * data.len();
         let data_byte_size = data_byte_size;
 
-        let compute_module = device.create_shader_module(ShaderModuleDescriptor {
+        let compute_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/command_buffer.push_constants.comp.spv")),
         })?;
 
@@ -223,7 +223,7 @@ fn dispatch_indirect() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let compute_module = device.create_shader_module(ShaderModuleDescriptor {
+        let compute_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!(
                 "shaders/command_buffer.copy_buffer_with_compute_shader.comp.spv"
             )),

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -20,7 +20,7 @@ fn copy_buffer_with_compute_shader() {
             )),
         })?;
 
-        let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             bindings: &[
                 BindGroupLayoutBinding {
                     binding: 0,
@@ -121,7 +121,7 @@ fn push_constants() {
             code: Cow::Borrowed(include_bytes!("shaders/command_buffer.push_constants.comp.spv")),
         })?;
 
-        let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             bindings: &[BindGroupLayoutBinding {
                 binding: 0,
                 visibility: ShaderStageFlags::COMPUTE,
@@ -229,7 +229,7 @@ fn dispatch_indirect() {
             )),
         })?;
 
-        let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             bindings: &[
                 BindGroupLayoutBinding {
                     binding: 0,

--- a/tests/command_buffer.rs
+++ b/tests/command_buffer.rs
@@ -35,7 +35,7 @@ fn copy_buffer_with_compute_shader() {
             ],
         })?;
 
-        let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout.clone()],
             push_constant_ranges: vec![],
         })?;
@@ -129,7 +129,7 @@ fn push_constants() {
             }],
         })?;
 
-        let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout.clone()],
             push_constant_ranges: vec![PushConstantRange {
                 offset: 0,
@@ -244,7 +244,7 @@ fn dispatch_indirect() {
             ],
         })?;
 
-        let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout.clone()],
             push_constant_ranges: vec![],
         })?;

--- a/tests/command_encoder.rs
+++ b/tests/command_encoder.rs
@@ -10,7 +10,7 @@ fn create_command_encoder() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let mut command_encoder = device.create_command_encoder()?;
+        let mut command_encoder = device.create_command_encoder(None)?;
 
         let compute_pass = command_encoder.begin_compute_pass();
         compute_pass.end_pass();
@@ -59,7 +59,7 @@ fn submit_command_buffer() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let mut command_encoder = device.create_command_encoder()?;
+        let mut command_encoder = device.create_command_encoder(None)?;
 
         let compute_pass = command_encoder.begin_compute_pass();
         compute_pass.end_pass();

--- a/tests/command_encoder.rs
+++ b/tests/command_encoder.rs
@@ -15,7 +15,7 @@ fn create_command_encoder() {
         let compute_pass = command_encoder.begin_compute_pass();
         compute_pass.end_pass();
 
-        let texture = device.create_texture(TextureDescriptor {
+        let texture = device.create_texture(&TextureDescriptor {
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,
             usage: TextureUsageFlags::OUTPUT_ATTACHMENT,
@@ -64,7 +64,7 @@ fn submit_command_buffer() {
         let compute_pass = command_encoder.begin_compute_pass();
         compute_pass.end_pass();
 
-        let texture = device.create_texture(TextureDescriptor {
+        let texture = device.create_texture(&TextureDescriptor {
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,
             usage: TextureUsageFlags::OUTPUT_ATTACHMENT,

--- a/tests/fence.rs
+++ b/tests/fence.rs
@@ -28,7 +28,7 @@ fn is_signaled_after_wait() {
         let fence1 = queue.create_fence()?;
         assert_eq!(false, fence1.is_signaled());
 
-        let encoder = device.create_command_encoder()?;
+        let encoder = device.create_command_encoder(None)?;
 
         queue.submit(&[encoder.finish()?])?;
 

--- a/tests/instance.rs
+++ b/tests/instance.rs
@@ -19,13 +19,13 @@ fn instance_request_adapter() {
         let options = AdapterOptions {
             power_preference: PowerPreference::HighPerformance,
         };
-        let adapter = instance.get_adapter(options)?;
+        let adapter = instance.get_adapter(&options)?;
         assert!(!adapter.name().is_empty());
 
         let options = AdapterOptions {
             power_preference: PowerPreference::LowPower,
         };
-        let adapter = instance.get_adapter(options)?;
+        let adapter = instance.get_adapter(&options)?;
         assert!(!adapter.name().is_empty());
 
         Ok(instance)
@@ -38,7 +38,7 @@ fn instance_create_device() {
     vki::validate(|| {
         let instance = Instance::new()?;
         let options = AdapterOptions::default();
-        let adapter = instance.get_adapter(options)?;
+        let adapter = instance.get_adapter(&options)?;
         let _device = adapter.create_device(&DeviceDescriptor::default())?;
 
         Ok(instance)

--- a/tests/instance.rs
+++ b/tests/instance.rs
@@ -39,7 +39,7 @@ fn instance_create_device() {
         let instance = Instance::new()?;
         let options = AdapterOptions::default();
         let adapter = instance.get_adapter(options)?;
-        let _device = adapter.create_device(DeviceDescriptor::default())?;
+        let _device = adapter.create_device(&DeviceDescriptor::default())?;
 
         Ok(instance)
     });

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -70,7 +70,7 @@ fn create_compute_pipeline() {
         let shader_module_descriptor = ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.comp.spv")),
         };
-        let shader_module = device.create_shader_module(shader_module_descriptor)?;
+        let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
             bindings: &[
@@ -116,11 +116,11 @@ fn create_render_pipeline() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let vertex_shader_module = device.create_shader_module(ShaderModuleDescriptor {
+        let vertex_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.vert.spv")),
         })?;
 
-        let fragment_shader_module = device.create_shader_module(ShaderModuleDescriptor {
+        let fragment_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.frag.spv")),
         })?;
 
@@ -231,11 +231,11 @@ fn create_multi_sample_render_pipeline() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
 
-        let vertex_shader_module = device.create_shader_module(ShaderModuleDescriptor {
+        let vertex_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.vert.spv")),
         })?;
 
-        let fragment_shader_module = device.create_shader_module(ShaderModuleDescriptor {
+        let fragment_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.frag.spv")),
         })?;
 
@@ -423,7 +423,7 @@ fn set_bind_group() {
         let shader_module_descriptor = ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.set_bind_group.comp.spv")),
         };
-        let shader_module = device.create_shader_module(shader_module_descriptor)?;
+        let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
             bindings: &[
@@ -567,7 +567,7 @@ fn set_bind_group_out_of_order() {
         let shader_module_descriptor = ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.set_bind_group.comp.spv")),
         };
-        let shader_module = device.create_shader_module(shader_module_descriptor)?;
+        let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
             bindings: &[
@@ -713,7 +713,7 @@ fn set_bind_group_dynamic_offsets() {
         let shader_module_descriptor = ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/pipeline.set_bind_group.comp.spv")),
         };
-        let shader_module = device.create_shader_module(shader_module_descriptor)?;
+        let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
             bindings: &[

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -68,7 +68,7 @@ fn create_compute_pipeline() {
         let (instance, _adapter, device) = support::init()?;
 
         let shader_module_descriptor = ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.comp.spv")),
+            code: include_bytes!("shaders/pipeline.comp.spv"),
         };
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
@@ -117,11 +117,11 @@ fn create_render_pipeline() {
         let (instance, _adapter, device) = support::init()?;
 
         let vertex_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.vert.spv")),
+            code: include_bytes!("shaders/pipeline.vert.spv"),
         })?;
 
         let fragment_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.frag.spv")),
+            code: include_bytes!("shaders/pipeline.frag.spv"),
         })?;
 
         #[rustfmt::skip]
@@ -232,11 +232,11 @@ fn create_multi_sample_render_pipeline() {
         let (instance, _adapter, device) = support::init()?;
 
         let vertex_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.vert.spv")),
+            code: include_bytes!("shaders/pipeline.vert.spv"),
         })?;
 
         let fragment_shader_module = device.create_shader_module(&ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.frag.spv")),
+            code: include_bytes!("shaders/pipeline.frag.spv"),
         })?;
 
         #[rustfmt::skip]
@@ -421,7 +421,7 @@ fn set_bind_group() {
         let (instance, _adapter, device) = support::init()?;
 
         let shader_module_descriptor = ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.set_bind_group.comp.spv")),
+            code: include_bytes!("shaders/pipeline.set_bind_group.comp.spv"),
         };
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
@@ -565,7 +565,7 @@ fn set_bind_group_out_of_order() {
         let (instance, _adapter, device) = support::init()?;
 
         let shader_module_descriptor = ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.set_bind_group.comp.spv")),
+            code: include_bytes!("shaders/pipeline.set_bind_group.comp.spv"),
         };
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
@@ -711,7 +711,7 @@ fn set_bind_group_dynamic_offsets() {
         let (instance, _adapter, device) = support::init()?;
 
         let shader_module_descriptor = ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/pipeline.set_bind_group.comp.spv")),
+            code: include_bytes!("shaders/pipeline.set_bind_group.comp.spv"),
         };
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -257,7 +257,7 @@ fn create_multi_sample_render_pipeline() {
             size: uniform_buffer_size,
         })?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout.clone(),
             bindings: vec![BindGroupBinding {
                 binding: 0,
@@ -518,7 +518,7 @@ fn set_bind_group() {
         })?;
         let texture_view = texture.create_default_view()?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout,
             bindings: vec![
                 BindGroupBinding {
@@ -662,7 +662,7 @@ fn set_bind_group_out_of_order() {
         })?;
         let texture_view = texture.create_default_view()?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout,
             // Note that the order of the array elements does not match the layout,
             // but the `binding` values correspond to the correct layout bindings.
@@ -808,7 +808,7 @@ fn set_bind_group_dynamic_offsets() {
         })?;
         let texture_view = texture.create_default_view()?;
 
-        let bind_group = device.create_bind_group(BindGroupDescriptor {
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
             layout: bind_group_layout,
             bindings: vec![
                 BindGroupBinding {

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -492,7 +492,7 @@ fn set_bind_group() {
             offset: 0,
             format: BufferViewFormat::Texture(TextureFormat::RGBA32Float),
         })?;
-        let sampler = device.create_sampler(SamplerDescriptor {
+        let sampler = device.create_sampler(&SamplerDescriptor {
             mag_filter: FilterMode::Nearest,
             min_filter: FilterMode::Nearest,
             mipmap_filter: FilterMode::Nearest,
@@ -636,7 +636,7 @@ fn set_bind_group_out_of_order() {
             offset: 0,
             format: BufferViewFormat::Texture(TextureFormat::RGBA32Float),
         })?;
-        let sampler = device.create_sampler(SamplerDescriptor {
+        let sampler = device.create_sampler(&SamplerDescriptor {
             mag_filter: FilterMode::Nearest,
             min_filter: FilterMode::Nearest,
             mipmap_filter: FilterMode::Nearest,
@@ -782,7 +782,7 @@ fn set_bind_group_dynamic_offsets() {
             offset: 0,
             format: BufferViewFormat::Texture(TextureFormat::RGBA32Float),
         })?;
-        let sampler = device.create_sampler(SamplerDescriptor {
+        let sampler = device.create_sampler(&SamplerDescriptor {
             mag_filter: FilterMode::Nearest,
             min_filter: FilterMode::Nearest,
             mipmap_filter: FilterMode::Nearest,

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -49,7 +49,7 @@ fn create_pipeline_layout() {
                 },
             ],
         };
-        let bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         let pipeline_layout_descriptor = PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout],
@@ -86,7 +86,7 @@ fn create_compute_pipeline() {
                 },
             ],
         };
-        let bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         let pipeline_layout_descriptor = PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout],
@@ -125,7 +125,7 @@ fn create_render_pipeline() {
         })?;
 
         #[rustfmt::skip]
-        let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             bindings: &[
                 BindGroupLayoutBinding {
                     binding: 0,
@@ -240,7 +240,7 @@ fn create_multi_sample_render_pipeline() {
         })?;
 
         #[rustfmt::skip]
-        let bind_group_layout = device.create_bind_group_layout(BindGroupLayoutDescriptor {
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
             bindings: &[
                 BindGroupLayoutBinding {
                     binding: 0,
@@ -454,7 +454,7 @@ fn set_bind_group() {
                 },
             ],
         };
-        let bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         let pipeline_layout_descriptor = PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout.clone()],
@@ -598,7 +598,7 @@ fn set_bind_group_out_of_order() {
                 },
             ],
         };
-        let bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         let pipeline_layout_descriptor = PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout.clone()],
@@ -744,7 +744,7 @@ fn set_bind_group_dynamic_offsets() {
                 },
             ],
         };
-        let bind_group_layout = device.create_bind_group_layout(bind_group_layout_descriptor)?;
+        let bind_group_layout = device.create_bind_group_layout(&bind_group_layout_descriptor)?;
 
         let pipeline_layout_descriptor = PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout.clone()],

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -252,7 +252,7 @@ fn create_multi_sample_render_pipeline() {
 
         let uniform_buffer_size = (std::mem::size_of::<f32>() * 16) as _;
 
-        let uniform_buffer = device.create_buffer(BufferDescriptor {
+        let uniform_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::UNIFORM | BufferUsageFlags::TRANSFER_DST,
             size: uniform_buffer_size,
         })?;
@@ -276,7 +276,7 @@ fn create_multi_sample_render_pipeline() {
             normal: [f32; 3],
         }
 
-        let vertex_buffer = device.create_buffer(BufferDescriptor {
+        let vertex_buffer = device.create_buffer(&BufferDescriptor {
             usage: BufferUsageFlags::VERTEX,
             size: (3 * std::mem::size_of::<Vertex>()) as _,
         })?;
@@ -475,15 +475,15 @@ fn set_bind_group() {
 
         let compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
 
-        let uniform_buffer = device.create_buffer(BufferDescriptor {
+        let uniform_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::UNIFORM,
         })?;
-        let storage_buffer = device.create_buffer(BufferDescriptor {
+        let storage_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::STORAGE,
         })?;
-        let image_buffer = device.create_buffer(BufferDescriptor {
+        let image_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::STORAGE, // TODO: texel storage
         })?;
@@ -619,15 +619,15 @@ fn set_bind_group_out_of_order() {
 
         let compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
 
-        let uniform_buffer = device.create_buffer(BufferDescriptor {
+        let uniform_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::UNIFORM,
         })?;
-        let storage_buffer = device.create_buffer(BufferDescriptor {
+        let storage_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::STORAGE,
         })?;
-        let image_buffer = device.create_buffer(BufferDescriptor {
+        let image_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::STORAGE, // TODO: texel storage
         })?;
@@ -765,15 +765,15 @@ fn set_bind_group_dynamic_offsets() {
 
         let compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
 
-        let uniform_buffer = device.create_buffer(BufferDescriptor {
+        let uniform_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::UNIFORM,
         })?;
-        let storage_buffer = device.create_buffer(BufferDescriptor {
+        let storage_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::STORAGE,
         })?;
-        let image_buffer = device.create_buffer(BufferDescriptor {
+        let image_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
             usage: BufferUsageFlags::STORAGE, // TODO: texel storage
         })?;

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -56,7 +56,7 @@ fn create_pipeline_layout() {
             push_constant_ranges: vec![],
         };
 
-        let _pipeline_layout = device.create_pipeline_layout(pipeline_layout_descriptor)?;
+        let _pipeline_layout = device.create_pipeline_layout(&pipeline_layout_descriptor)?;
 
         Ok(instance)
     });
@@ -93,7 +93,7 @@ fn create_compute_pipeline() {
             push_constant_ranges: vec![],
         };
 
-        let pipeline_layout = device.create_pipeline_layout(pipeline_layout_descriptor)?;
+        let pipeline_layout = device.create_pipeline_layout(&pipeline_layout_descriptor)?;
 
         let pipeline_stage_descriptor = PipelineStageDescriptor {
             entry_point: Cow::Borrowed("main"),
@@ -135,7 +135,7 @@ fn create_render_pipeline() {
             ],
         })?;
 
-        let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout],
             push_constant_ranges: vec![],
         })?;
@@ -265,7 +265,7 @@ fn create_multi_sample_render_pipeline() {
             }],
         })?;
 
-        let pipeline_layout = device.create_pipeline_layout(PipelineLayoutDescriptor {
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
             bind_group_layouts: vec![bind_group_layout],
             push_constant_ranges: vec![],
         })?;
@@ -461,7 +461,7 @@ fn set_bind_group() {
             push_constant_ranges: vec![],
         };
 
-        let pipeline_layout = device.create_pipeline_layout(pipeline_layout_descriptor)?;
+        let pipeline_layout = device.create_pipeline_layout(&pipeline_layout_descriptor)?;
 
         let pipeline_stage_descriptor = PipelineStageDescriptor {
             entry_point: Cow::Borrowed("main"),
@@ -605,7 +605,7 @@ fn set_bind_group_out_of_order() {
             push_constant_ranges: vec![],
         };
 
-        let pipeline_layout = device.create_pipeline_layout(pipeline_layout_descriptor)?;
+        let pipeline_layout = device.create_pipeline_layout(&pipeline_layout_descriptor)?;
 
         let pipeline_stage_descriptor = PipelineStageDescriptor {
             entry_point: Cow::Borrowed("main"),
@@ -751,7 +751,7 @@ fn set_bind_group_dynamic_offsets() {
             push_constant_ranges: vec![],
         };
 
-        let pipeline_layout = device.create_pipeline_layout(pipeline_layout_descriptor)?;
+        let pipeline_layout = device.create_pipeline_layout(&pipeline_layout_descriptor)?;
 
         let pipeline_stage_descriptor = PipelineStageDescriptor {
             entry_point: Cow::Borrowed("main"),

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -105,7 +105,7 @@ fn create_compute_pipeline() {
             compute_stage: pipeline_stage_descriptor,
         };
 
-        let _compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
+        let _compute_pipeline = device.create_compute_pipeline(&compute_pipeline_descriptor)?;
 
         Ok(instance)
     });
@@ -220,7 +220,7 @@ fn create_render_pipeline() {
             sample_count: 1,
         };
 
-        let _render_pipeline = device.create_render_pipeline(render_pipeline_descriptor)?;
+        let _render_pipeline = device.create_render_pipeline(&render_pipeline_descriptor)?;
 
         Ok(instance)
     });
@@ -342,7 +342,7 @@ fn create_multi_sample_render_pipeline() {
             sample_count,
         };
 
-        let pipeline = device.create_render_pipeline(render_pipeline_descriptor)?;
+        let pipeline = device.create_render_pipeline(&render_pipeline_descriptor)?;
 
         let size = Extent3D {
             width: 800,
@@ -473,7 +473,7 @@ fn set_bind_group() {
             compute_stage: pipeline_stage_descriptor,
         };
 
-        let compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
+        let compute_pipeline = device.create_compute_pipeline(&compute_pipeline_descriptor)?;
 
         let uniform_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
@@ -617,7 +617,7 @@ fn set_bind_group_out_of_order() {
             compute_stage: pipeline_stage_descriptor,
         };
 
-        let compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
+        let compute_pipeline = device.create_compute_pipeline(&compute_pipeline_descriptor)?;
 
         let uniform_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,
@@ -763,7 +763,7 @@ fn set_bind_group_dynamic_offsets() {
             compute_stage: pipeline_stage_descriptor,
         };
 
-        let compute_pipeline = device.create_compute_pipeline(compute_pipeline_descriptor)?;
+        let compute_pipeline = device.create_compute_pipeline(&compute_pipeline_descriptor)?;
 
         let uniform_buffer = device.create_buffer(&BufferDescriptor {
             size: 1024,

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -31,7 +31,7 @@ fn create_pipeline_layout() {
         let (instance, _adapter, device) = support::init()?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::VERTEX,
@@ -73,7 +73,7 @@ fn create_compute_pipeline() {
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::COMPUTE,
@@ -126,7 +126,7 @@ fn create_render_pipeline() {
 
         #[rustfmt::skip]
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::VERTEX,
@@ -241,7 +241,7 @@ fn create_multi_sample_render_pipeline() {
 
         #[rustfmt::skip]
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::VERTEX,
@@ -426,7 +426,7 @@ fn set_bind_group() {
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::COMPUTE,
@@ -570,7 +570,7 @@ fn set_bind_group_out_of_order() {
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::COMPUTE,
@@ -716,7 +716,7 @@ fn set_bind_group_dynamic_offsets() {
         let shader_module = device.create_shader_module(&shader_module_descriptor)?;
 
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor {
-            bindings: &[
+            bindings: vec![
                 BindGroupLayoutBinding {
                     binding: 0,
                     visibility: ShaderStageFlags::COMPUTE,

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -355,7 +355,7 @@ fn create_multi_sample_render_pipeline() {
         let format = TextureFormat::B8G8R8A8Unorm;
         let usage = TextureUsageFlags::OUTPUT_ATTACHMENT;
 
-        let frame_texture = device.create_texture(TextureDescriptor {
+        let frame_texture = device.create_texture(&TextureDescriptor {
             sample_count: 1,
             size,
             mip_level_count,
@@ -372,7 +372,7 @@ fn create_multi_sample_render_pipeline() {
             texture: frame_texture,
         };
 
-        let output_texture = device.create_texture(TextureDescriptor {
+        let output_texture = device.create_texture(&TextureDescriptor {
             sample_count,
             size,
             mip_level_count,
@@ -503,7 +503,7 @@ fn set_bind_group() {
             address_mode_w: AddressMode::ClampToEdge,
             compare_function: CompareFunction::Never,
         })?;
-        let texture = device.create_texture(TextureDescriptor {
+        let texture = device.create_texture(&TextureDescriptor {
             size: Extent3D {
                 width: 256,
                 height: 256,
@@ -647,7 +647,7 @@ fn set_bind_group_out_of_order() {
             address_mode_w: AddressMode::ClampToEdge,
             compare_function: CompareFunction::Never,
         })?;
-        let texture = device.create_texture(TextureDescriptor {
+        let texture = device.create_texture(&TextureDescriptor {
             size: Extent3D {
                 width: 256,
                 height: 256,
@@ -793,7 +793,7 @@ fn set_bind_group_dynamic_offsets() {
             address_mode_w: AddressMode::ClampToEdge,
             compare_function: CompareFunction::Never,
         })?;
-        let texture = device.create_texture(TextureDescriptor {
+        let texture = device.create_texture(&TextureDescriptor {
             size: Extent3D {
                 width: 256,
                 height: 256,

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -384,7 +384,7 @@ fn create_multi_sample_render_pipeline() {
 
         let output_view = output_texture.create_default_view()?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let mut render_pass = encoder.begin_render_pass(RenderPassDescriptor {
             color_attachments: &[RenderPassColorAttachmentDescriptor {
@@ -544,7 +544,7 @@ fn set_bind_group() {
             ],
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let mut compute_pass = encoder.begin_compute_pass();
         compute_pass.set_pipeline(&compute_pipeline);
@@ -690,7 +690,7 @@ fn set_bind_group_out_of_order() {
             ],
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let mut compute_pass = encoder.begin_compute_pass();
         compute_pass.set_pipeline(&compute_pipeline);
@@ -834,7 +834,7 @@ fn set_bind_group_dynamic_offsets() {
             ],
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let mut compute_pass = encoder.begin_compute_pass();
         compute_pass.set_pipeline(&compute_pipeline);

--- a/tests/sampler.rs
+++ b/tests/sampler.rs
@@ -7,7 +7,7 @@ fn create_sampler() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
         let descriptor = SamplerDescriptor::default();
-        let _sampler = device.create_sampler(descriptor)?;
+        let _sampler = device.create_sampler(&descriptor)?;
         Ok(instance)
     });
 }

--- a/tests/shader.rs
+++ b/tests/shader.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use vki::ShaderModuleDescriptor;
 
 pub mod support;
@@ -8,7 +7,7 @@ fn create_shader_module() {
     vki::validate(|| {
         let (instance, _adapter, device) = support::init()?;
         let descriptor = ShaderModuleDescriptor {
-            code: Cow::Borrowed(include_bytes!("shaders/shader.vert.spv")),
+            code: include_bytes!("shaders/shader.vert.spv"),
         };
         let _shader_module = device.create_shader_module(&descriptor)?;
         Ok(instance)

--- a/tests/shader.rs
+++ b/tests/shader.rs
@@ -10,7 +10,7 @@ fn create_shader_module() {
         let descriptor = ShaderModuleDescriptor {
             code: Cow::Borrowed(include_bytes!("shaders/shader.vert.spv")),
         };
-        let _shader_module = device.create_shader_module(descriptor)?;
+        let _shader_module = device.create_shader_module(&descriptor)?;
         Ok(instance)
     });
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -41,7 +41,7 @@ pub fn init() -> Result<(Instance, Adapter, Device), Box<dyn std::error::Error>>
     log::debug!("power_preference: {:?}", power_preference);
     let instance = Instance::new()?;
     let adapter = instance.get_adapter(AdapterOptions { power_preference })?;
-    let device = adapter.create_device(DeviceDescriptor::default())?;
+    let device = adapter.create_device(&DeviceDescriptor::default())?;
 
     Ok((instance, adapter, device))
 }
@@ -54,7 +54,7 @@ pub fn init_with_window(
     let adapter = instance.get_adapter(AdapterOptions::default())?;
     let surface_descriptor = winit_surface_descriptor!(window);
     let surface = instance.create_surface(&surface_descriptor)?;
-    let device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
+    let device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;
     let swapchain_descriptor = swapchain_descriptor(&surface);
     let swapchain = device.create_swapchain(&swapchain_descriptor, None)?;
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -40,7 +40,7 @@ pub fn init() -> Result<(Instance, Adapter, Device), Box<dyn std::error::Error>>
     let power_preference = select_power_preference();
     log::debug!("power_preference: {:?}", power_preference);
     let instance = Instance::new()?;
-    let adapter = instance.get_adapter(AdapterOptions { power_preference })?;
+    let adapter = instance.get_adapter(&AdapterOptions { power_preference })?;
     let device = adapter.create_device(&DeviceDescriptor::default())?;
 
     Ok((instance, adapter, device))
@@ -51,7 +51,7 @@ pub fn init_with_window(
 ) -> Result<(Instance, Adapter, Device, Surface, Swapchain), Box<dyn std::error::Error>> {
     init_environment();
     let instance = Instance::new()?;
-    let adapter = instance.get_adapter(AdapterOptions::default())?;
+    let adapter = instance.get_adapter(&AdapterOptions::default())?;
     let surface_descriptor = winit_surface_descriptor!(window);
     let surface = instance.create_surface(&surface_descriptor)?;
     let device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -56,7 +56,7 @@ pub fn init_with_window(
     let surface = instance.create_surface(&surface_descriptor)?;
     let device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
     let swapchain_descriptor = swapchain_descriptor(&surface);
-    let swapchain = device.create_swapchain(swapchain_descriptor, None)?;
+    let swapchain = device.create_swapchain(&swapchain_descriptor, None)?;
 
     Ok((instance, adapter, device, surface, swapchain))
 }

--- a/tests/surface.rs
+++ b/tests/surface.rs
@@ -12,7 +12,7 @@ fn winit_surface() {
     let _ = pretty_env_logger::try_init();
     vki::validate(|| {
         let instance = Instance::new()?;
-        let adapter = instance.get_adapter(AdapterOptions::default())?;
+        let adapter = instance.get_adapter(&AdapterOptions::default())?;
 
         let event_loop = winit::event_loop::EventLoop::new();
         let window = winit::window::WindowBuilder::new()
@@ -36,7 +36,7 @@ fn glfw_surface() {
     let _ = pretty_env_logger::try_init();
     vki::validate(|| {
         let instance = Instance::new()?;
-        let adapter = instance.get_adapter(AdapterOptions::default())?;
+        let adapter = instance.get_adapter(&AdapterOptions::default())?;
 
         let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
         glfw.window_hint(glfw::WindowHint::Visible(false));

--- a/tests/surface.rs
+++ b/tests/surface.rs
@@ -25,7 +25,7 @@ fn winit_surface() {
 
         let surface_descriptor = winit_surface_descriptor!(window);
         let surface = instance.create_surface(&surface_descriptor)?;
-        let _device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
+        let _device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;
 
         Ok(instance)
     });
@@ -47,7 +47,7 @@ fn glfw_surface() {
 
         let surface_descriptor = glfw_surface_descriptor!(window);
         let surface = instance.create_surface(&surface_descriptor)?;
-        let _device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
+        let _device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;
 
         Ok(instance)
     });

--- a/tests/swapchain.rs
+++ b/tests/swapchain.rs
@@ -29,7 +29,7 @@ fn create_swapchain() {
         let device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
         let swapchain_descriptor = support::swapchain_descriptor(&surface);
 
-        let _swapchain = device.create_swapchain(swapchain_descriptor, None)?;
+        let _swapchain = device.create_swapchain(&swapchain_descriptor, None)?;
 
         Ok(instance)
     });
@@ -50,7 +50,7 @@ fn recreate_swapchain_without_old() {
         let device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
         let swapchain_descriptor = support::swapchain_descriptor(&surface);
 
-        let swapchain = device.create_swapchain(swapchain_descriptor, None)?;
+        let swapchain = device.create_swapchain(&swapchain_descriptor, None)?;
 
         // TODO: This test explicitly invalidates the previous swapchain, There currently
         //       isn't any way to have that previous swapchain *implicitly* invalidated,
@@ -58,7 +58,7 @@ fn recreate_swapchain_without_old() {
         //       below may fail (horribly with a segmentation fault).
         drop(swapchain);
 
-        let _swapchain = device.create_swapchain(swapchain_descriptor, None)?;
+        let _swapchain = device.create_swapchain(&swapchain_descriptor, None)?;
 
         Ok(instance)
     });
@@ -130,7 +130,7 @@ fn recreate_after_resize() {
             } => {
                 let swapchain_descriptor = support::swapchain_descriptor(&surface);
                 swapchain = device
-                    .create_swapchain(swapchain_descriptor, Some(&swapchain))
+                    .create_swapchain(&swapchain_descriptor, Some(&swapchain))
                     .expect("Failed to re-create swapchain");
                 resized = true;
             }

--- a/tests/swapchain.rs
+++ b/tests/swapchain.rs
@@ -23,7 +23,7 @@ fn create_swapchain() {
         support::init_environment();
         let (_event_loop, window) = support::headless_window()?;
         let instance = Instance::new()?;
-        let adapter = instance.get_adapter(AdapterOptions::default())?;
+        let adapter = instance.get_adapter(&AdapterOptions::default())?;
         let surface_descriptor = winit_surface_descriptor!(window);
         let surface = instance.create_surface(&surface_descriptor)?;
         let device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;
@@ -44,7 +44,7 @@ fn recreate_swapchain_without_old() {
         support::init_environment();
         let (_event_loop, window) = support::headless_window()?;
         let instance = Instance::new()?;
-        let adapter = instance.get_adapter(AdapterOptions::default())?;
+        let adapter = instance.get_adapter(&AdapterOptions::default())?;
         let surface_descriptor = winit_surface_descriptor!(window);
         let surface = instance.create_surface(&surface_descriptor)?;
         let device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;

--- a/tests/swapchain.rs
+++ b/tests/swapchain.rs
@@ -26,7 +26,7 @@ fn create_swapchain() {
         let adapter = instance.get_adapter(AdapterOptions::default())?;
         let surface_descriptor = winit_surface_descriptor!(window);
         let surface = instance.create_surface(&surface_descriptor)?;
-        let device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
+        let device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;
         let swapchain_descriptor = support::swapchain_descriptor(&surface);
 
         let _swapchain = device.create_swapchain(&swapchain_descriptor, None)?;
@@ -47,7 +47,7 @@ fn recreate_swapchain_without_old() {
         let adapter = instance.get_adapter(AdapterOptions::default())?;
         let surface_descriptor = winit_surface_descriptor!(window);
         let surface = instance.create_surface(&surface_descriptor)?;
-        let device = adapter.create_device(DeviceDescriptor::default().with_surface_support(&surface))?;
+        let device = adapter.create_device(&DeviceDescriptor::default().with_surface_support(&surface))?;
         let swapchain_descriptor = support::swapchain_descriptor(&surface);
 
         let swapchain = device.create_swapchain(&swapchain_descriptor, None)?;

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -139,7 +139,7 @@ fn copy_texture_to_texture() {
             origin: Origin3D { x: 0, y: 0, z: 0 },
         };
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         encoder.copy_texture_to_texture(src, dst, size);
 
@@ -177,7 +177,7 @@ fn blit_texture_to_texture_generate_mipmaps() {
             mip_level_count,
         })?;
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         let mut mip_width = width;
         let mut mip_height = height;
@@ -328,7 +328,7 @@ fn copy_buffer_to_texture() {
             origin: Origin3D { x: 0, y: 0, z: 0 },
         };
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         encoder.copy_buffer_to_texture(src, dst, size);
 
@@ -384,7 +384,7 @@ fn copy_texture_to_buffer() {
             origin: Origin3D { x: 0, y: 0, z: 0 },
         };
 
-        let mut encoder = device.create_command_encoder()?;
+        let mut encoder = device.create_command_encoder(None)?;
 
         encoder.copy_texture_to_buffer(src, dst, size);
 

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -299,7 +299,7 @@ fn copy_buffer_to_texture() {
         let (width, height, depth) = (1024, 1024, 1);
         let size = Extent3D { width, height, depth };
 
-        let buffer1 = device.create_buffer(BufferDescriptor {
+        let buffer1 = device.create_buffer(&BufferDescriptor {
             size: (width * height) as usize * std::mem::size_of::<f32>(),
             usage: BufferUsageFlags::TRANSFER_SRC,
         })?;
@@ -355,7 +355,7 @@ fn copy_texture_to_buffer() {
         let (width, height, depth) = (1024, 1024, 1);
         let size = Extent3D { width, height, depth };
 
-        let buffer1 = device.create_buffer(BufferDescriptor {
+        let buffer1 = device.create_buffer(&BufferDescriptor {
             size: (width * height) as usize * std::mem::size_of::<f32>(),
             usage: BufferUsageFlags::TRANSFER_DST,
         })?;

--- a/tests/texture.rs
+++ b/tests/texture.rs
@@ -25,7 +25,7 @@ fn create_texture() {
             format: TextureFormat::R8G8B8A8Unorm,
         };
 
-        let _texture = device.create_texture(descriptor)?;
+        let _texture = device.create_texture(&descriptor)?;
 
         Ok(instance)
     });
@@ -50,7 +50,7 @@ fn create_default_texture_view() {
             format: TextureFormat::R8G8B8A8Unorm,
         };
 
-        let texture = device.create_texture(descriptor)?;
+        let texture = device.create_texture(&descriptor)?;
         let _texture_view = texture.create_default_view()?;
 
         Ok(instance)
@@ -78,7 +78,7 @@ fn create_texture_and_cube_view() {
             format: TextureFormat::R8G8B8A8Unorm,
         };
 
-        let texture = device.create_texture(descriptor)?;
+        let texture = device.create_texture(&descriptor)?;
 
         let texture_view_descriptor = TextureViewDescriptor {
             dimension: TextureViewDimension::Cube,
@@ -105,7 +105,7 @@ fn copy_texture_to_texture() {
 
         let size = Extent3D { width, height, depth };
 
-        let texture1 = device.create_texture(TextureDescriptor {
+        let texture1 = device.create_texture(&TextureDescriptor {
             usage: TextureUsageFlags::TRANSFER_SRC,
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,
@@ -115,7 +115,7 @@ fn copy_texture_to_texture() {
             mip_level_count: 1,
         })?;
 
-        let texture2 = device.create_texture(TextureDescriptor {
+        let texture2 = device.create_texture(&TextureDescriptor {
             usage: TextureUsageFlags::SAMPLED | TextureUsageFlags::TRANSFER_DST,
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,
@@ -167,7 +167,7 @@ fn blit_texture_to_texture_generate_mipmaps() {
 
         let mip_level_count = (width.max(height) as f32).log2().floor() as u32 + 1;
 
-        let texture = device.create_texture(TextureDescriptor {
+        let texture = device.create_texture(&TextureDescriptor {
             usage: TextureUsageFlags::SAMPLED | TextureUsageFlags::TRANSFER_SRC | TextureUsageFlags::TRANSFER_DST,
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,
@@ -256,7 +256,7 @@ fn create_depth_texture_and_view() {
             format: TextureFormat::D32Float,
         };
 
-        let texture = device.create_texture(descriptor)?;
+        let texture = device.create_texture(&descriptor)?;
 
         let _texture_view = texture.create_default_view()?;
 
@@ -283,7 +283,7 @@ fn create_depth_stencil_texture_and_view() {
             format: TextureFormat::D32FloatS8Uint,
         };
 
-        let texture = device.create_texture(descriptor)?;
+        let texture = device.create_texture(&descriptor)?;
 
         let _texture_view = texture.create_default_view()?;
 
@@ -304,7 +304,7 @@ fn copy_buffer_to_texture() {
             usage: BufferUsageFlags::TRANSFER_SRC,
         })?;
 
-        let texture1 = device.create_texture(TextureDescriptor {
+        let texture1 = device.create_texture(&TextureDescriptor {
             usage: TextureUsageFlags::TRANSFER_DST,
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,
@@ -360,7 +360,7 @@ fn copy_texture_to_buffer() {
             usage: BufferUsageFlags::TRANSFER_DST,
         })?;
 
-        let texture1 = device.create_texture(TextureDescriptor {
+        let texture1 = device.create_texture(&TextureDescriptor {
             usage: TextureUsageFlags::TRANSFER_SRC,
             sample_count: 1,
             format: TextureFormat::R8G8B8A8Unorm,


### PR DESCRIPTION
With the exception of RenderPassDescriptor (and friends), all descriptors no longer have lifetime bounds. This should allow for easier management of those descriptors.

The RenderPassDescriptor(s) need to be constructed per frame in any case. Allowing for those to be cloned out of scope might encourage attempting to re-use them, which may have an unintended side effect of holding references to the swap chain images longer than intended.